### PR TITLE
fix(Env): Improve error messaging

### DIFF
--- a/src/env/create.test.ts
+++ b/src/env/create.test.ts
@@ -3,43 +3,45 @@ import { create } from './create';
 describe('create', () => {
   const VAR = 'ABC_123_DEF_456';
 
+  const parse = (value: string, _name: string) => JSON.parse(value);
+
   beforeEach(() => delete process.env[VAR]);
 
   describe('with default', () => {
     it('maps a set environment variable', () => {
       process.env[VAR] = '123';
-      expect(create<number>(JSON.parse)(VAR, { default: undefined })).toBe(123);
+      expect(create<number>(parse)(VAR, { default: undefined })).toBe(123);
     });
 
     it('throws on parsing error', () => {
       process.env[VAR] = '}';
       expect(() =>
-        create(JSON.parse)(VAR, { default: undefined }),
+        create(parse)(VAR, { default: undefined }),
       ).toThrowErrorMatchingInlineSnapshot(
         `"Unexpected token } in JSON at position 0"`,
       );
     });
 
     it('defaults on unset environment variable', () =>
-      expect(create(JSON.parse)(VAR, { default: undefined })).toBeUndefined());
+      expect(create(parse)(VAR, { default: undefined })).toBeUndefined());
   });
 
   describe('without default', () => {
     it('maps a set environment variable', () => {
       process.env[VAR] = '123';
-      expect(create<number>(JSON.parse)(VAR)).toBe(123);
+      expect(create<number>(parse)(VAR)).toBe(123);
     });
 
     it('throws on parsing error', () => {
       process.env[VAR] = '}';
-      expect(() => create(JSON.parse)(VAR)).toThrowErrorMatchingInlineSnapshot(
+      expect(() => create(parse)(VAR)).toThrowErrorMatchingInlineSnapshot(
         `"Unexpected token } in JSON at position 0"`,
       );
     });
 
     it('throws on unset environment variable', () =>
-      expect(() => create(JSON.parse)(VAR)).toThrowErrorMatchingInlineSnapshot(
-        `"process.env.ABC_123_DEF_456 not set"`,
+      expect(() => create(parse)(VAR)).toThrowErrorMatchingInlineSnapshot(
+        `"process.env.ABC_123_DEF_456 is not set"`,
       ));
   });
 });

--- a/src/env/create.ts
+++ b/src/env/create.ts
@@ -2,19 +2,19 @@
  * Create a function that reads an environment variable and runs it through the
  * provided parsing function.
  */
-export const create = <T>(parse: (value: string) => T) => <U = T>(
+export const create = <T>(parse: (value: string, name: string) => T) => <U = T>(
   name: string,
   opts?: Readonly<{ default: U }>,
 ): T | U => {
   const value = process.env[name];
 
   if (typeof value !== 'undefined') {
-    return parse(value);
+    return parse(value, name);
   }
 
   if (typeof opts !== 'undefined') {
     return opts.default;
   }
 
-  throw Error(`process.env.${name} not set`);
+  throw Error(`process.env.${name} is not set`);
 };

--- a/src/env/parsers.test.ts
+++ b/src/env/parsers.test.ts
@@ -8,7 +8,7 @@ describe('nonNegativeInteger', () => {
   ] as const;
 
   it.each(happyCases)('parses %s', (_, input, output) =>
-    expect(parsers.nonNegativeInteger(input)).toBe(output),
+    expect(parsers.nonNegativeInteger(input, 'PORT')).toBe(output),
   );
 
   const sadCases = [
@@ -29,21 +29,27 @@ describe('nonNegativeInteger', () => {
   ] as const;
 
   it.each(sadCases)('throws on %s', (_, input) =>
-    expect(() => parsers.nonNegativeInteger(input)).toThrow(),
+    expect(() => parsers.nonNegativeInteger(input, 'PORT')).toThrow(
+      'process.env.PORT is not a non-negative integer',
+    ),
   );
 });
 
 describe('noop', () => {
-  it('passes through value', () => expect(parsers.noop('abc')).toBe('abc'));
+  it('passes through value', () =>
+    expect(parsers.noop('abc', 'VERSION')).toBe('abc'));
 });
 
 describe('oneOf', () => {
   const parse = parsers.oneOf(['local', 'prod']);
 
-  it('passes through value in list', () => expect(parse('prod')).toBe('prod'));
+  it('passes through value in list', () =>
+    expect(parse('prod', 'ENVIRONMENT')).toBe('prod'));
 
   it('throws on value not in list', () =>
-    expect(() => parse('dev')).toThrowErrorMatchingInlineSnapshot(
-      `"not a supported choice: 'dev'"`,
+    expect(() =>
+      parse('dev', 'ENVIRONMENT'),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"process.env.ENVIRONMENT is not a supported choice: 'dev'. Expected one of: ['local', 'prod']"`,
     ));
 });

--- a/src/env/parsers.ts
+++ b/src/env/parsers.ts
@@ -1,22 +1,30 @@
-export const nonNegativeInteger = (input: string): number => {
+export const nonNegativeInteger = (input: string, name: string): number => {
   const int = parseInt(input, 10);
 
   if (int < 0 || !Number.isSafeInteger(int) || input !== String(int)) {
-    throw Error(`not a non-negative integer: '${input}'`);
+    throw Error(
+      `process.env.${name} is not a non-negative integer: '${input}'`,
+    );
   }
 
   return int;
 };
 
-export const noop = <T>(input: T): T => input;
+export const noop = <T>(input: T, _name: string): T => input;
 
 export const oneOf = <T>(choices: readonly T[]) => {
   const isChoice = (value: unknown): value is typeof choices[number] =>
     new Set<unknown>(choices).has(value);
 
-  return (input: unknown): typeof choices[number] => {
+  return (input: unknown, name: string): typeof choices[number] => {
     if (!isChoice(input)) {
-      throw Error(`not a supported choice: '${String(input)}'`);
+      throw Error(
+        `process.env.${name} is not a supported choice: '${String(
+          input,
+        )}'. Expected one of: [${choices
+          .map((choice) => `'${String(choice)}'`)
+          .join(', ')}]`,
+      );
     }
 
     return input;


### PR DESCRIPTION
It's pretty common to run into these errors on application deployments due to misconfiguration. Unfortunately `not a supported choice: 'dev'` doesn't give you much to go off of.